### PR TITLE
Speedup

### DIFF
--- a/R/fitting.R
+++ b/R/fitting.R
@@ -1,11 +1,5 @@
 #' @param an is the constant used in the BIC calculation. The default choice is
 #'   from Wang et al. (2009)
-#' @param exact If exact=FALSE, then the results from glmnet uses linear
-#'   interpolation to make predictions for values of lambda that do not coincide
-#'   with those used in the fitting algorithm. While this is often a good
-#'   approximation, it can sometimes be a bit coarse. With exact=TRUE (default),
-#'   the model is refit before predictions are made. See
-#'   \code{\link[glmnet]{coef.glmnet}} for more details.
 #' @references Wang, H., Li, B. and Leng, C. (2009) Shrinkage tuning parameter
 #'   selection with a diverging number of parameters.J. R. Statist. Soc. B, 71,
 #'   671–683.
@@ -15,11 +9,11 @@ penfam <- function(x, y, phi, lambda = NULL,
                    eta_init = 0.5,
                    maxit = 100,
                    fdev = 1e-4,
+                   alpha = 1, # elastic net mixing param. 1 is lasso, 0 is ridge
                    thresh_glmnet = 1e-10, # this is for glmnet
                    epsilon = 1e-5, # this is for penfam
                    an = log(log(n)) * log(n),
-                   tol.kkt = 1e-9,
-                   exact = T) {
+                   tol.kkt = 1e-9) {
 
   # rm(list=ls())
   # source("~/git_repositories/penfam/R/fitting.R")
@@ -77,10 +71,10 @@ penfam <- function(x, y, phi, lambda = NULL,
   uty <- crossprod(U, y)
 
   # get sequence of tuning parameters
-  (lamb <- lambda_sequence(x = utx, y = uty, eigenvalues = Lambda, nlambda = nlambda,
+  lamb <- lambda_sequence(x = utx, y = uty, eigenvalues = Lambda, nlambda = nlambda,
                            lambda_min_ratio = lambda_min_ratio,
                            eta_init = eta_init, epsilon = epsilon,
-                           tol.kkt = tol.kkt))
+                           tol.kkt = tol.kkt)
 
   lambda_max <- lamb$sequence[[1]]
 
@@ -168,6 +162,7 @@ penfam <- function(x, y, phi, lambda = NULL,
                               y = uty,
                               family = "gaussian",
                               weights = wi,
+                              alpha = alpha,
                               penalty.factor = c(0, rep(1, p)),
                               standardize = FALSE,
                               intercept = FALSE,

--- a/R/methods.R
+++ b/R/methods.R
@@ -6,7 +6,7 @@
 print.penfam <- function (x, digits = max(3, getOption("digits") - 3), ...) {
   cat("\nCall: ", deparse(x$call), "\n\n")
   print(cbind(Df = x$result[,"Df"],
-              `%Dev` = signif(x$result[,"%Dev"], digits),
+              `Deviance` = signif(x$result[,"Deviance"], digits),
               Lambda = signif(x$result[,"Lambda"], digits),
               BIC = signif(x$result[,"BIC"], digits)))
 }
@@ -103,7 +103,7 @@ predict.penfam <- function(object, newx, s = NULL,
 
 
 
-plot.penfam <- function(x, type = c("coef","BIC", "QQranef","QQresid", "fitted", "Tukey-Anscombe"),
+plot.penfam <- function(x, type = c("coef","BIC", "QQranef","QQresid", "predicted", "Tukey-Anscombe"),
                         xvar=c("norm","lambda","dev"), s = x$lambda_min,
                         label=FALSE, sign.lambda = 1, ...){
   xvar <- match.arg(xvar)
@@ -111,7 +111,7 @@ plot.penfam <- function(x, type = c("coef","BIC", "QQranef","QQresid", "fitted",
 
   if (any(type == "coef")) {
     plotCoef(x$beta, lambda=drop(x$result[,"Lambda"]),
-             df=drop(x$result[,"Df"]), dev=drop(x$result[,"%Dev"]),
+             df=drop(x$result[,"Df"]), dev=drop(x$result[,"Deviance"]),
              label=label, xvar=xvar,...)
   }
 
@@ -132,16 +132,23 @@ plot.penfam <- function(x, type = c("coef","BIC", "QQranef","QQresid", "fitted",
     qqline(x$residuals[, s], col = "red")
   }
 
-  if (any(type == "fitted")){
+  if (any(type == "predicted")){
     if (s %ni% rownames(x$result)) stop("value for s not in lambda sequence")
-    plot(x$fitted[, s], drop(x$y), xlab = "fitted values", ylab = "observed values",
-         main = "Observed vs. Fitted values")
+    plot(x$predicted[, s], drop(x$y), xlab = "predicted response (XB + b)", ylab = "observed response",
+         main = "Observed vs. Predicted response")
+    abline(a = 0, b = 1, col = "red")
+  }
+
+  if (any(type == "predicted")){
+    if (s %ni% rownames(x$result)) stop("value for s not in lambda sequence")
+    plot(x$predicted[, s], drop(x$y), xlab = "predicted response (XB + b)", ylab = "observed response",
+         main = "Observed vs. Predicted response")
     abline(a = 0, b = 1, col = "red")
   }
 
   if (any(type == "Tukey-Anscombe")){
     plot(x$fitted[, s], x$residuals[, s], main = "Tukey-Anscombe Plot",
-         xlab = "fitted values", ylab = "residuals")
+         xlab = "fitted values (XB)", ylab = "residuals")
     abline(h = 0, col = "red")
   }
 

--- a/R/sim-data.R
+++ b/R/sim-data.R
@@ -41,10 +41,12 @@ kappa(Phi)
 
 # simulation parameters
 eta <- 0.35
-sigma2 <- 3
-p <- 1000
+sigma2 <- 4
+
 b0 <- 3
-b <- c(runif(10, 0.8,1.2), rep(0,980), runif(10, -1.2, -0.8))
+b <- c(runif(10, 0.8,1.2), rep(0,580), runif(10, -1.2, -0.8))
+
+p <- length(b)
 
 n <- nrow(Phi)
 
@@ -55,9 +57,36 @@ P <- mvrnorm(1, mu = rep(0, n), Sigma = eta * sigma2 * Phi)
 E <- mvrnorm(1, mu = rep(0, n), Sigma = (1 - eta) * sigma2 * diag(n))
 
 X <- mvrnorm(n, rep(1,p), diag(p))
+wi <- sample(1:10, n, replace = T)
+# times <- 1:p
+# H <- abs(outer(times, times, "-"))
+# V1 <- 0.1^H
+# V2 <- 0.3^H
+# V3 <- 0.5^H
+# V4 <- 0.7^H
+# V5 <- 0.9^H
+#
+# X1 <- MASS::mvrnorm(n = n/5, mu = rep(0,p), Sigma = V1)
+# X2 <- MASS::mvrnorm(n = n/5, mu = rep(0,p), Sigma = V2)
+# X3 <- MASS::mvrnorm(n = n/5, mu = rep(0,p), Sigma = V3)
+# X4 <- MASS::mvrnorm(n = n/5, mu = rep(0,p), Sigma = V4)
+# X5 <- MASS::mvrnorm(n = n/5, mu = rep(0,p), Sigma = V5)
+# X <- rbind(X1,X2,X3,X4,X5)
+#
+# X <- mvrnorm(n, rep(1,p), diag(p))
 
 Y <- b0 + X %*% b + P + E
 
-
-
-
+# fit1 <- glmnet(X,Y)
+# plot(fit1)
+# fit1$lambda
+#
+#
+# fit2 <- glmnet(X,Y, lambda = c(7, 6, 5, fit1$lambda[3]))
+# coef(fit2, s = fit1$lambda[3]-.001, exact = T)
+#
+# plot(fit2)
+#
+#
+#
+#

--- a/kkt.Rmd
+++ b/kkt.Rmd
@@ -9,7 +9,7 @@ output:
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = FALSE)
+knitr::opts_chunk$set(echo = TRUE)
 rm(list=ls())
 ```
 
@@ -41,8 +41,6 @@ $$
 
 
 ## Simulate Data
-
-
 
 
 ```{r}
@@ -80,8 +78,7 @@ wi <- rep(1, n)
 # wi <- sample(1:10, size = n, replace = T)
 
 (m2 <- glmnet(y = Y, x = X, standardize = F, thresh = threshold, weights = wi))
-(m2 <- glmnet(y = Y, x = X, standardize = F, thresh = threshold))
-max(m2$lambda)
+
 B <- as.matrix(m2$beta)
 
 out_print <- matrix(NA, nrow = length(m2$lambda), ncol = 3,
@@ -93,7 +90,7 @@ out_print <- matrix(NA, nrow = length(m2$lambda), ncol = 3,
 
 
 
-```{r, echo=FALSE}
+```{r, echo=TRUE}
 for (lambda in colnames(B)) {
   # lambda = colnames(B)[1]
   beta <- B[, lambda, drop = F]
@@ -126,33 +123,6 @@ for (lambda in colnames(B)) {
 }
 
 out_print
-
-mysd <- function(y) sqrt(sum((y - mean(y)) ^ 2)/length(y))
-sy <- as.vector(scale(Y, scale = mysd(Y)))
-sx <- scale(X, scale = apply(X, 2, mysd))
-sx <- as.matrix(sx, ncol = p, nrow = n)
-dim(sx)
-(lambda.max <- max(abs(colSums(wi * sx * drop(sy)))) / n)
-m2$lambda
-
-sx <- scale(X,scale=apply(X,2,mysd))
-sx <- as.matrix(sx,ncol=p,nrow=n)
-sy <- as.vector(scale(Y, scale = mysd(Y)))
-max(abs(colSums(sx*sy)))/100
-fitGLM <- glmnet(sx, sy, standardize = F)
-max(fitGLM$lambda)
-
-
-rm(list = ls())
-set.seed(1)
-library("glmnet")
-x <- matrix(rnorm(100*20),100,20)
-y <- rnorm(100)
-fitGLM <- glmnet(x,y)
-max(fitGLM$lambda)
-
-
-
 ```
 
 
@@ -203,13 +173,6 @@ for (lambda in colnames(B)) {
   if (sum(abs(g[oo]) > tol.kkt) > 0) plot(abs(g[oo]))
 
 }
-
-(lambda.max <- max(abs(colSums(((1 / sum(wi_scaled)) * (wi_scaled * X) * drop(Y))))))
-
-(lambda.max <- max(abs(colSums(((1 / sum(wi)) * (wi * X) * drop(Y))))))
-  
-  
-m2$lambda
 
 out_print
 ```

--- a/report.Rmd
+++ b/report.Rmd
@@ -1,7 +1,7 @@
 ---
-title: "Initial Implementation of penfam algorithm"
+title: "Newer Implementation of penfam algorithm"
 author: "Sahir"
-date: "May 10, 2017"
+date: "August 24, 2017"
 output:
   html_document:
     toc: true
@@ -38,6 +38,7 @@ source("~/git_repositories/penfam/R/plot.R")
 
 ```{r}
 pacman::p_load(MASS) 
+pacman::p_load(Matrix)
 pacman::p_load(glmnet)
 pacman::p_load(progress)
 pacman::p_load(magrittr)
@@ -68,14 +69,14 @@ kappa(Phi)
 
 ### Simulation parameters
 ```{r}
-eta <- 0.25
+eta <- 0.5
 sigma2 <- 4
 
 # intercept
 b0 <- 3 
 
 # true betas
-b <- c(runif(10, 0.8,1.2), rep(0,1980), runif(10, -1.2, -0.8)) 
+b <- c(runif(10, 0.8,1.2), rep(0,80), runif(10, -1.2, -0.8)) 
 ```
 
 ### Simulate data
@@ -92,9 +93,21 @@ P <- mvrnorm(1, mu = rep(0, n), Sigma = eta * sigma2 * Phi)
 E <- mvrnorm(1, mu = rep(0, n), Sigma = (1 - eta) * sigma2 * diag(n))
 
 # independent predictors
-X <- mvrnorm(n, rep(1,p), diag(p))
-dim(X)
+# X <- mvrnorm(n, rep(1,p), diag(p))
 
+# Correlated predictors
+rho1 <- 0.7
+rho2 <- 0.9
+
+k1 <- rho1 ^ toeplitz(seq_len(p/2))
+diag(k1) <- 1
+k2 <- rho2 ^ toeplitz(seq_len(p/2))
+diag(k2) <- 1
+k <- Matrix::bdiag(k1,k2) 
+  
+X <- mvrnorm(n, rep(1,p), k)
+
+# pheatmap::pheatmap(cor(X))
 # response
 Y <- b0 + X %*% b + P + E
 ```
@@ -110,20 +123,23 @@ We provide these two main options for fitting the `penfam` model by specifying t
 - `exact = FALSE`: this will use a linear interpolation 
 In both cases, the entire lasso path is being fit.
 
-## Fit the penfam model with `exact = TRUE`
+**This is no longer being implemented.**
 
-We first fit using the option `exact = TRUE`
+Instead we are providing two lambdas to glmnet, the `.Machine$double.xmax` and the actual value of lambda.
 
-```{r}
+## Fit the penfam model
+
+```{r, message=FALSE}
 system.time(
-  exact <- penfam(x = X, 
+  lasso <- penfam(x = X, 
                   y = Y, 
                   phi = Phi, 
-                  thresh_glmnet = 1e-10,
-                  epsilon = 1e-9,
+                  thresh_glmnet = 1e-12,
+                  epsilon = 1e-6,
+                  fdev = 1e-5,
+                  alpha = 1,
                   tol.kkt = 1e-3,
                   nlambda = 100,
-                  exact = FALSE,
                   an = log(log(n)) * log(n),
                   lambda_min_ratio  = ifelse(n < p, 0.01, 0.001),
                   eta_init = 0.5,
@@ -131,16 +147,17 @@ system.time(
 )
 ```
 
+
 Print method:
-```{r}
-exact
+```{r, eval=TRUE}
+lasso
 ```
 
 
-### KKT Checks
+## KKT Checks
 
 ```{r}
-exact$result[,c(-2,-3,-4,-10)]
+lasso$result[,c(-2,-3,-4,-10)]
 ```
 
 
@@ -148,37 +165,39 @@ exact$result[,c(-2,-3,-4,-10)]
 ### Coefficients at Minimum BIC
 
 ```{r}
-coef(exact, s = exact$lambda_min)
+coef(lasso, s = lasso$lambda_min)
+
 ```
 
 ### Non-zero Coefficients at Minimum BIC
 
 ```{r}
-predict(exact, type = "nonzero", s = exact$lambda_min)
+predict(lasso, type = "nonzero", s = lasso$lambda_min)
+
 ```
 
 ### Plot of Coefficient Paths
 
 ```{r}
-plot(exact, type = "coef", xvar = "norm")
-plot(exact, type = "coef", xvar = "lambda")
-plot(exact, type = "coef", xvar = "dev")
+plot(lasso, type = "coef", xvar = "norm")
+plot(lasso, type = "coef", xvar = "lambda")
+plot(lasso, type = "coef", xvar = "dev")
 ```
 
 
 ### Plot of BIC as a function of Tuning parameters
 
 ```{r}
-plot(exact, type = "BIC")
+plot(lasso, type = "BIC")
 ```
 
 
 ### Compare Estimated vs. Truth
 
 ```{r, fig.keep='last'}
-plot(coef(exact, s = exact$lambda_min), 
+plot(coef(lasso, s = lasso$lambda_min), 
      pch = 19, col = "red", 
-     ylim = range(c(b0, b, eta, sigma2, drop(coef(exact, s = exact$lambda_min)))))
+     ylim = range(c(b0, b, eta, sigma2, drop(coef(lasso, s = lasso$lambda_min)))))
 
 points(seq_along(c(b0, b, eta, sigma2)), c(b0, b, eta, sigma2), pch = 19, col = "blue")
 
@@ -193,22 +212,22 @@ legend("bottomleft",
 ### Prediction of Random Effects
 
 ```{r}
-plot(exact, type = c("QQranef"), s = exact$lambda_min)
-plot(exact$randomeff[,exact$lambda_min])
+plot(lasso, type = c("QQranef"), s = lasso$lambda_min)
+plot(lasso$randomeff[,lasso$lambda_min])
 ```
 
 
 ### Tukey-Anscombe Plot
 
 ```{r}
-plot(exact, type = c("Tukey"), s = exact$lambda_min)
+plot(lasso, type = c("Tukey"), s = lasso$lambda_min)
 ```
 
 
 ### Residuals
 
 ```{r}
-plot(exact, type = c("QQresid"), s = exact$lambda_min)
+plot(lasso, type = c("QQresid"), s = lasso$lambda_min)
 ```
 
 
@@ -216,146 +235,8 @@ plot(exact, type = c("QQresid"), s = exact$lambda_min)
 
 
 ```{r}
-plot(exact, type = c("predicted"), s = exact$lambda_min)
+plot(lasso, type = c("predicted"), s = lasso$lambda_min)
 ```
 
-
-
-## Fit the penfam model with `exact = FALSE`
-
-Now we fit using the option `exact = FALSE`
-
-```{r}
-system.time(
-  approx <- penfam(x = X, 
-                   y = Y, 
-                   phi = Phi, 
-                   thresh_glmnet = 1e-10,
-                   epsilon = 1e-6,
-                   tol.kkt = 1e-4,
-                   nlambda = 50,
-                   exact = FALSE,
-                   an = log(log(n)) * log(n),
-                   lambda_min_ratio  = ifelse(n < p, 0.01, 0.001),
-                   eta_init = 0.5,
-                   maxit = 100) 
-)
-```
-
-Print method:
-```{r}
-approx
-```
-
-
-### KKT Checks
-
-```{r}
-approx$result[,c(-2,-3,-4,-10)]
-```
-
-
-
-### Coefficients at Minimum BIC
-
-```{r}
-coef(approx, s = approx$lambda_min)
-```
-
-### Non-zero Coefficients at Minimum BIC
-
-```{r}
-predict(approx, type = "nonzero", s = approx$lambda_min)
-```
-
-### Plot of Coefficient Paths
-
-```{r}
-plot(approx, type = "coef", xvar = "norm")
-plot(approx, type = "coef", xvar = "lambda")
-plot(approx, type = "coef", xvar = "dev")
-```
-
-
-### Plot of BIC as a function of Tuning parameters
-
-```{r}
-plot(approx, type = "BIC")
-```
-
-
-### Compare Estimated vs. Truth
-
-```{r, fig.keep='last'}
-plot(coef(approx, s = approx$lambda_min), 
-     pch = 19, col = "red", 
-     ylim = range(c(b0, b, eta, sigma2, drop(coef(approx, s = approx$lambda_min)))))
-
-points(seq_along(c(b0, b, eta, sigma2)), c(b0, b, eta, sigma2), pch = 19, col = "blue")
-
-legend("bottomleft",
-       legend = c("Estimated", "Truth"),
-       col = c("red","blue"),
-       pch = c(19, 19),
-       bg = "gray90")
-```
-
-
-### Prediction of Random Effects
-
-```{r}
-plot(approx, type = c("QQranef"), s = approx$lambda_min)
-```
-
-
-### Tukey-Anscombe Plot
-
-```{r}
-plot(approx, type = c("Tukey"), s = approx$lambda_min)
-```
-
-
-### Residuals
-
-```{r}
-plot(approx, type = c("QQresid"), s = approx$lambda_min)
-```
-
-
-### Predicted vs. Observed response
-
-
-```{r}
-plot(approx, type = c("predicted"), s = approx$lambda_min)
-```
-
-
-
-
-## Compare Exact to Approximate
-
-```{r}
-exact_coef <- coef(exact, s = exact$lambda_min)
-approx_coef <- coef(approx, s = approx$lambda_min)
-plot(drop(exact_coef),
-     drop(approx_coef),
-     xlab = "exact", ylab = "approximate", main = "Estimated parameters at minimum BIC")
-```
-
-```{r}
-cbind(exact_coef, approx_coef)
-```
-
-
-### Pearson Correlation
-```{r}
-cor(drop(exact_coef), drop(approx_coef))
-```
-
-### Spearman Correlation
-```{r}
-cor(drop(exact_coef), drop(approx_coef),
-    method = "spearman")
-```
 
 

--- a/report.Rmd
+++ b/report.Rmd
@@ -69,13 +69,13 @@ kappa(Phi)
 ### Simulation parameters
 ```{r}
 eta <- 0.25
-sigma2 <- 3
+sigma2 <- 4
 
 # intercept
 b0 <- 3 
 
 # true betas
-b <- c(runif(10, 0.8,1.2), rep(0,80), runif(10, -1.2, -0.8)) 
+b <- c(runif(10, 0.8,1.2), rep(0,1980), runif(10, -1.2, -0.8)) 
 ```
 
 ### Simulate data
@@ -123,7 +123,7 @@ system.time(
                   epsilon = 1e-9,
                   tol.kkt = 1e-3,
                   nlambda = 100,
-                  exact = TRUE,
+                  exact = FALSE,
                   an = log(log(n)) * log(n),
                   lambda_min_ratio  = ifelse(n < p, 0.01, 0.001),
                   eta_init = 0.5,
@@ -194,6 +194,7 @@ legend("bottomleft",
 
 ```{r}
 plot(exact, type = c("QQranef"), s = exact$lambda_min)
+plot(exact$randomeff[,exact$lambda_min])
 ```
 
 
@@ -211,11 +212,11 @@ plot(exact, type = c("QQresid"), s = exact$lambda_min)
 ```
 
 
-### Fitted vs. Observed response
+### Predicted vs. Observed response
 
 
 ```{r}
-plot(exact, type = c("fitted"), s = exact$lambda_min)
+plot(exact, type = c("predicted"), s = exact$lambda_min)
 ```
 
 
@@ -232,7 +233,7 @@ system.time(
                    thresh_glmnet = 1e-10,
                    epsilon = 1e-6,
                    tol.kkt = 1e-4,
-                   nlambda = 100,
+                   nlambda = 50,
                    exact = FALSE,
                    an = log(log(n)) * log(n),
                    lambda_min_ratio  = ifelse(n < p, 0.01, 0.001),
@@ -321,11 +322,11 @@ plot(approx, type = c("QQresid"), s = approx$lambda_min)
 ```
 
 
-### Fitted vs. Observed response
+### Predicted vs. Observed response
 
 
 ```{r}
-plot(approx, type = c("fitted"), s = approx$lambda_min)
+plot(approx, type = c("predicted"), s = approx$lambda_min)
 ```
 
 


### PR DESCRIPTION
In this PR, we have sped up the code by removing the `exact=TRUE/FALSE` argument when extract the fitted coefficients from `glmnet`. Instead we are providing two lambdas to `glmnet`, the `.Machine$double.xmax` and the actual value of lambda. We have also removed unecessary code. The KKT checks are also working now. Next step is to make the KKT checks into a vignette, and compartmentalize the fitting function so that it does only the fitting. The BIC, residuals, KKT checks should be separate functions performed elsewhere.